### PR TITLE
Remove jackson-annotations

### DIFF
--- a/src/main/scala/nl/gn0s1s/jackson/versioncheck/JacksonVersionCheckPlugin.scala
+++ b/src/main/scala/nl/gn0s1s/jackson/versioncheck/JacksonVersionCheckPlugin.scala
@@ -38,7 +38,6 @@ object JacksonVersionCheckPlugin extends AutoPlugin {
   }
 
   private val jacksonModules = Set(
-    "jackson-annotations",
     "jackson-core",
     "jackson-databind",
     "jackson-dataformat-avro",


### PR DESCRIPTION
since it uses its own version numbering since 2.20. See https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.20#compatibility-versioning.