### PR TITLE
Fix NonMatchingVersionsException

### DIFF
--- a/src/main/scala/nl/gn0s1s/jackson/versioncheck/JacksonVersionCheckPlugin.scala
+++ b/src/main/scala/nl/gn0s1s/jackson/versioncheck/JacksonVersionCheckPlugin.scala
@@ -170,7 +170,7 @@ object JacksonVersionCheckPlugin extends AutoPlugin {
     } yield verifyJacksonModuleScalaRequirement(jacksonDatabindVersion, jacksonModuleScalaVersion, log)
 
     if (failBuildOnNonMatchingVersions && !(jackson2Ok && jackson3Ok))
-      throw NonMatchingVersionsException
+      throw NonMatchingVersionsException()
   }
 
   private def extractMajorMinor(version: String): (Int, Int) =

--- a/src/main/scala/nl/gn0s1s/jackson/versioncheck/NonMatchingVersionsException.scala
+++ b/src/main/scala/nl/gn0s1s/jackson/versioncheck/NonMatchingVersionsException.scala
@@ -1,3 +1,3 @@
 package nl.gn0s1s.jackson.versioncheck
 
-case object NonMatchingVersionsException extends IllegalStateException("Non-matching Jackson module versions found")
+case class NonMatchingVersionsException() extends IllegalStateException("Non-matching Jackson module versions found")


### PR DESCRIPTION
`Throwable` instances are not intended for reuse as they are stateful and contain mutable stacktrace information. Hence, global singleton Throwables should be avoided.

